### PR TITLE
Restart uWSGI after setting up apps.

### DIFF
--- a/manifests/manage_app.pp
+++ b/manifests/manage_app.pp
@@ -25,5 +25,6 @@ define uwsgi::manage_app(
     mode    => '0644',
     content => template("${module_name}/${conf_template}"),
     require => Package[$::uwsgi::package_name],
+    notify  => Service[$::uwsgi::service_name],
   }
 }


### PR DESCRIPTION
This very simple patch restarts uWSGI after enabling a new app.
