### PR TITLE
Add support for extra configs for uWSGI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 uwsgi
 ===
-This module installs and configures uWSGI Emperor service. If you
-want to configure and run uWSGI apps, see `uwsgi::app` class.
+This module installs [uWSGI][] and configures it for [Emperor mode][]. If you
+want to configure and run uWSGI apps, see the `uwsgi::app` class.
 
-This module is most flexible and most easier to manage when used with hiera.
+This module is most flexible and easiest to manage when used with [Hiera][].
+
+[uWSGI]: http://uwsgi-docs.readthedocs.org/en/latest/index.html
+[Emperor mode]: http://uwsgi-docs.readthedocs.org/en/latest/Emperor.html
+[Hiera]: http://docs.puppetlabs.com/hiera/1/index.html
 
 ## Classes
 
@@ -20,11 +24,23 @@ Default: `running`.
 * `onboot` - whether to enable or disable the service on boot. Valid values:
 `true`, `false` or `manual`. Default: `true`.
 
+* `config` - Valid [uWSGI configuration options][] for the uWSGI server. It is a hash, so any
+uWSGI valid key-value pairs as parameters.
+
+[uWSGI configuration options]: http://uwsgi-docs.readthedocs.org/en/latest/Options.html
+
 
 #### Examples
     ---
     classes:
       - uwsgi
+    
+    # override default params
+    uwsgi::onboot: manual
+    
+    # Add extra configs to default wsgi config
+    uwsgi::config:
+      chmod-socket: 664
 
 ### uwsgi::app
 This class allows you to configure uWSGI apps.
@@ -33,8 +49,8 @@ This class allows you to configure uWSGI apps.
 * `ensure` - Determines the state of the application configuration.
 Default: `present`. Valid values: `present` or `absent`.
 
-* `config` - Valid uwsgi app specific configuration. It is a hash, so any
-uwsgi valid key-value pairs parameters.
+* `config` - Valid [uWSGI configuration options][] specific to an app. It is a hash, so any
+uWSGI valid key-value pairs as parameters.
 
 * `uid` - User name to run uwsgi process on for this app. User must exist.
 Default: `www-data` for Ubuntu/Debian and `uwsgi` for Fedora/RedHat.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class uwsgi(
     $service = 'running',
     $onboot  = true,
     $package = 'installed',
+    $config = undef,
 ) {
   case $::operatingsystem {
     Fedora: {

--- a/templates/uwsgi.ini.erb
+++ b/templates/uwsgi.ini.erb
@@ -11,3 +11,12 @@ emperor-tyrant = true
 master = true
 autoload = true
 log-date = true
+<%
+if @config
+  @config.sort.each do |key, value|
+-%>
+<%= key %> = <%= value%>
+<%
+  end
+end
+-%>


### PR DESCRIPTION
I added support for passing extra configs to the uWSGI server configuration. I needed this personally in order to control socket permissions (per [this](http://uwsgi-docs.readthedocs.org/en/latest/tutorials/Django_and_nginx.html#if-that-doesn-t-work)), but could see it being useful in general. Here are specific changes.
- Add config param to uwsgi class
- Update uwsgi template to handle extra config
- Update README to reflect uwsgi config changes
- Misc README cleanups
