### PR TITLE
Update for ubuntu default runlevel

### DIFF
--- a/files/uwsgi_upstart.conf
+++ b/files/uwsgi_upstart.conf
@@ -4,7 +4,7 @@
 # uWSGI Emperor process Upstart script
 #
 description "uWSGI Emperor"
-start on runlevel [345]
+start on runlevel [2345]
 stop on runlevel [06]
 
 pre-start exec mkdir -p /run/uwsgi


### PR DESCRIPTION
Ubuntu's default runlevel for a headless server is '2'. Before this, the
uwsgi service never starts on boot.

If possible, I would love to have this integrated quickly. :godmode:
:tada: :heart: