### PR TITLE
fix future parser parser error and switch to osfamily instad of opera…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,23 +17,17 @@ class uwsgi(
     $package = 'installed',
     $config  = undef,
 ) {
-  case $::operatingsystem {
-    Fedora: {
+  case $::osfamily {
+    'RedHat': {
       $package_name   = 'uwsgi'
       $service_name   = 'uwsgi'
       $run_user       = 'uwsgi'
       $app_config_dir = '/etc/uwsgi.d'
     }
-    Ubuntu: {
+    'Debian': {
       $package_name   = 'uwsgi'
       $service_name   = 'uwsgi'
       $upstart_script = '/etc/init/uwsgi.conf'
-      $run_user       = 'www-data'
-      $app_config_dir = '/etc/uwsgi/apps-enabled'
-    }
-    Debian: {
-      $package_name   = 'uwsgi'
-      $service_name   = 'uwsgi'
       $run_user       = 'www-data'
       $app_config_dir = '/etc/uwsgi/apps-enabled'
     }


### PR DESCRIPTION
Hi Vaidas,

I've been using this module on a system undergoing compatibility testing with the Puppet Future Parser and I found (and corrected) and error for you.

I've also included a fix for https://github.com/vaijab/puppet-uwsgi/issues/4 (use `$::osfamily`) since it was easy to do at the same time.

The PR corrects the issue of having unquoted strings as labels in a case statement which is not allowed in the latest release (you end up in the default block as your attempting to compare a string to an undefined variable).

Thanks for your work on this module, I've been using it on a home project and it works great.

Cheers,
Geoff