### PR TITLE
Add separate parameters for config file ownership

### DIFF
--- a/manifests/manage_app.pp
+++ b/manifests/manage_app.pp
@@ -15,14 +15,17 @@ define uwsgi::manage_app(
   $config = undef,
   $uid    = $::uwsgi::run_user,
   $gid    = $::uwsgi::run_user,
+  $owner  = 'root',
+  $group  = 'root',
+  $mode   = '0644',
 ) {
   $conf_template = 'uwsgi_app.ini.erb'
 
   file { "${::uwsgi::app_config_dir}/${title}.ini":
     ensure  => $ensure,
-    owner   => $uid,
-    group   => $gid,
-    mode    => '0644',
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
     content => template("${module_name}/${conf_template}"),
     require => Package[$::uwsgi::package_name],
   }


### PR DESCRIPTION
The running process should not be allowed to configure its own app
config file.

One use case is if you are passing sensitive information via
environment variables. If that is the case, the app configuration
should not be globally readable.